### PR TITLE
Fix an issue of exposed coveralls repo_token

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,1 @@
-repo_token: LXbjHynXx7CMRWSuFTFOlbJeltdcFZJ5O
+service_name: travis-ci


### PR DESCRIPTION
According to [Coveralls docs](https://coveralls.io/docs/ruby), it seems that the option `repo_token` should be kept secret:

>  The option repo_token ...  should be kept secret -- anyone could use it to submit coverage data on your repo's behalf.

I fixed the issue and the result is seemed to be success: [ishida/itunes-client | Build #1 | Coveralls](https://coveralls.io/builds/78021)
